### PR TITLE
A workaround for the missing rt_tables file in boot2docker

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -27,6 +27,7 @@ if [ ! -f /etc/iproute2/rt_tables ]; then
     exit 1                                                                                               
   fi                                                                                                     
 fi  
+
 start_routing () {
   # Add a new route table that routes everything marked through the new container
   sudo mkdir -p /etc/iproute2


### PR DESCRIPTION
1. Adding the `dirname` allows to execute the script from any directory
2. Workaround for the misplaced rt_tables file cf. [#367](https://github.com/boot2docker/boot2docker/issues/367)
