### PR TITLE
updated boot2docker rt_tables location

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -24,6 +24,8 @@ start_routing () {
   if [ ! -e /etc/iproute2/rt_tables ]; then
     if [ -f /usr/local/etc/rt_tables ]; then
       sudo ln -s /usr/local/etc/rt_tables /etc/iproute2/rt_tables
+    elif [ -f /usr/local/etc/iproute2/rt_tables ]; then
+      sudo ln -s /usr/local/etc/iproute2/rt_tables /etc/iproute2/rt_tables
     fi
   fi
   ([ -e /etc/iproute2/rt_tables ] && grep TRANSPROXY /etc/iproute2/rt_tables >/dev/null) || \


### PR DESCRIPTION
recent versions of boot2docker use /usr/local/etc/iproute2/rt_tables