### PR TITLE
Revert "Update run.sh"

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # Script to maintain ip rules on the host when starting up a transparent
 # proxy server for docker.


### PR DESCRIPTION
This reverts commit 72732356eb9ab38a497553363ac241d62d7ad171.

Boot2docker is using busybox for /bin/sh and does not contain /bin/bash
I've tried running with /bin/sh instead of /bin/bash and at least with
busybox I have no problems. This helps which Docker Machine that uses
Boot2docker as well.