### PR TITLE
Fixed run.sh options, and persisting cache and key by default

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -3,8 +3,8 @@
 # Script to maintain ip rules on the host when starting up a transparent
 # proxy server for docker.
 
-CACHEDIR=${CACHEDIR:-/tmp/squid3}
-CERTDIR=${CACHEDIR:-/tmp/squid3_cert}
+CACHEDIR=${CACHEDIR:-/var/lib/docker-proxy/cache}
+CERTDIR=${CERTDIR:-/var/lib/docker-proxy/ssl}
 CONTAINER_NAME=${CONTAINER_NAME:-docker-proxy}
 if [ "$1" = 'ssl' ]; then
     WITH_SSL=yes


### PR DESCRIPTION
The SSL certificate directory was erroneously being set to use the cache directory `$CACHEDIR` - my bad.

Also, the default directories were in `/tmp`. This meant that every time the host computer was restarted, the cache - and more importantly, the CA certificate - were destroyed. Images that had been built using the old CA certificate would no longer be able to use the proxy, so it's important that the CA certificate at least is persisted by default. I don't mind so much about the cache. The default is now to use [`/var/lib`][1]`/docker-proxy` as the base directory - although we could use [`/var/tmp`][1] for the cache.

[1]: http://www.tldp.org/LDP/sag/html/var-fs.html