### PR TITLE
make source package repo available again [fix]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ MAINTAINER Kevin Littlejohn <kevin@littlejohn.id.au>, \
 
 # Install base dependencies.
 WORKDIR /root
+RUN sed -i 's/^# deb-src/deb-src/' /etc/apt/sources.list
 RUN export DEBIAN_FRONTEND=noninteractive TERM=linux \
     && apt-get update \
     && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
We need it for installing `squid3` sources.
All credits go to @Malvineous, see github issue #21.